### PR TITLE
Added a flexible route which can be filtered via request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
     _**https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/**_
 
-  - Find your Plex Section IDs: 
+  - Find your Plex Section IDs (key): 
 
     _**http://{your_plex_ip}:{your_plex_port}/library/sections?X-Plex-Token={your_plex_token}**_
 
@@ -126,10 +126,31 @@
                 additionalField:
                   field:
                     1: date_added
+
+      - Recently Added
+          id: #ABC123
+          icon: plex.png
+          widget:
+            type: customapi
+            url: http://{IP}:{port}/api/recent
+            requestBody: "{\"library\":\"all\"}"
+            display: list
+            mappings:
+              - field:
+                  0: title
+                additionalField:
+                  field:
+                    0: date_added
+              - field:
+                  1: title
+                additionalField:
+                  field:
+                    1: date_added
 ### Note:
   - You can use <code>date_added</code> as the first field, and <code>title</code> in the <code>additionalField</code>, if you prefer.
   - Script supports 50 most recently added Movies and TV Shows, sorted from most recent <code>0</code> to earliest <code>49</code>.
   - This limit can be changed in the script.
+  - Accepted values for the library key are <code>all</code>, library names eg. <code>Movies</code> or comma deliminated library names eg. <code>Movies,Series</code>.
 
 ### Acknowledgement:
 Special thanks to **haytada**, **MountainGod**, and **Plancke** in the Homepage Discord for all their help in making this happen! 

--- a/recently-added/docker-compose.yml
+++ b/recently-added/docker-compose.yml
@@ -2,13 +2,11 @@ version: "3.8"
 services:
   recently-added:
     container_name: recently-added
-    ports:
-      - <port>:8080
-    image: recently-added
+    build: .
     environment:
-      - TZ=<timezone>
+      - TZ=Europe/Malta
     networks:
-      - <network>
+      - services
 networks:
-  <network>:
+  services:
     external: true

--- a/recently-added/recently-added.py
+++ b/recently-added/recently-added.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 import requests
 from datetime import datetime
 
@@ -11,14 +11,17 @@ MOVIE_LIBRARY_ID = "your_movie_library_id"
 TV_LIBRARY_ID = "your_tv_library_id"
 PLEX_TOKEN = "your_plex_token"
 
-def get_recent_items(url, item_type):
+def get_recent_items(url, item_type = None):
     headers = {
         'Accept': 'application/json'
     }
     response = requests.get(url, headers=headers)
     if response.status_code == 200:
         data = response.json()
-        items = [item for item in data['MediaContainer']['Metadata'] if item['type'] == item_type]
+        if not item_type:
+            items = [item for item in data['MediaContainer']['Metadata']]
+        else:
+            items = [item for item in data['MediaContainer']['Metadata'] if item['type'] == item_type]
         sorted_items = sorted(items, key=lambda x: int(x['addedAt']), reverse=True)
         recent_items = sorted_items[:50]  # Take only the 50 most recently added items
         return recent_items
@@ -26,29 +29,86 @@ def get_recent_items(url, item_type):
         print(f"Failed to fetch data: {response.status_code}")
         return []
 
+def get_libraries() -> dict:
+    libraries = {}
+    plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections?X-Plex-Token={PLEX_TOKEN}"
+    headers = {
+        'Accept': 'application/json'
+    }
+    response = requests.get(plex_url, headers=headers)
+    if response.status_code == 200:
+        data = response.json()
+        for lib in data['MediaContainer']['Directory']:
+            libraries[lib['title']] = int(lib['key'])
+        return libraries
+    else:
+        print(f"Failed to fetch libraries: {response.status_code}")
+        return {}
+
 def format_date(timestamp):
     dt_object = datetime.fromtimestamp(int(timestamp))
     return dt_object.strftime("%b %d")
 
+@app.route('/api/recent', methods=['GET'])
+def recent():
+    data = request.get_json()
+    libraries = get_libraries()
+    formatted_items = []
+    if data['library'] == 'all':
+        for id in libraries.values():
+            plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{id}/all?X-Plex-Token={PLEX_TOKEN}"
+            recent_items_data = get_recent_items(plex_url)
+            if recent_items_data:
+                formatted_items = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_items_data]
+            else:
+                return jsonify({"message": "No recent items found."}), 404
+        return jsonify(formatted_items)
+    elif ',' in data['library']:
+        libs = str(data['library']).split(',')
+        for lib in libs:
+            plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{libraries[lib]}/all?X-Plex-Token={PLEX_TOKEN}"
+            recent_items_data = get_recent_items(plex_url)
+            if recent_items_data:
+                formatted_items = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_items_data]
+            else:
+                return jsonify({"message": "No recent items found."}), 404
+        return jsonify(formatted_items)
+    elif ',' not in data['library'] and not data['library'] == 'all':
+        plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{libraries[data['library']]}/all?X-Plex-Token={PLEX_TOKEN}"
+        recent_items_data = get_recent_items(plex_url)
+        if recent_items_data:
+            formatted_items = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_items_data]
+            return jsonify(formatted_items)
+        else:
+            return jsonify({"message": "No recent items found."}), 404
+    else:
+        return jsonify({"message": "No recent items found."}), 404
+
 @app.route('/api/recent_movies')
 def recent_movies():
-    plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{MOVIE_LIBRARY_ID}/all?X-Plex-Token={PLEX_TOKEN}"
-    recent_movies_data = get_recent_items(plex_url, 'movie')
-    if recent_movies_data:
-        formatted_movies = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_movies_data]
-        return jsonify(formatted_movies)
+    if not MOVIE_LIBRARY_ID == "your_movie_library_id":
+        plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{MOVIE_LIBRARY_ID}/all?X-Plex-Token={PLEX_TOKEN}"
+        recent_movies_data = get_recent_items(plex_url, 'movie')
+        if recent_movies_data:
+            formatted_movies = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_movies_data]
+            return jsonify(formatted_movies)
+        else:
+            return jsonify({"message": "No recent movies found."}), 404
     else:
-        return jsonify({"message": "No recent movies found."}), 404
+        return jsonify({"message": "MOVIE_LIBRARY_ID is not configured."}), 404
 
 @app.route('/api/recent_shows')
 def recent_shows():
-    plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{TV_LIBRARY_ID}/all?X-Plex-Token={PLEX_TOKEN}"
-    recent_shows_data = get_recent_items(plex_url, 'show')
-    if recent_shows_data:
-        formatted_shows = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_shows_data]
-        return jsonify(formatted_shows)
+    if not TV_LIBRARY_ID == "your_tv_library_id":
+        plex_url = f"http://{PLEX_IP}:{PLEX_PORT}/library/sections/{TV_LIBRARY_ID}/all?X-Plex-Token={PLEX_TOKEN}"
+        recent_shows_data = get_recent_items(plex_url, 'show')
+        if recent_shows_data:
+            formatted_shows = [{"title": item['title'], "date_added": format_date(item['addedAt'])} for item in recent_shows_data]
+            return jsonify(formatted_shows)
+        else:
+            return jsonify({"error": "No recent shows found."}), 404
     else:
-        return jsonify({"error": "No recent shows found."}), 404
+        return jsonify({"message": "TV_LIBRARY_ID is not configured."}), 404
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
This change doesn't break existing functionality however adds a new path `/api/recent` which accepts a request body in the format below:

```json
{
    "library": "all" 
}
```

Accepted values are `all`, library names eg. `Movies` or comma deliminated library names eg. `Movies,Series`.

Using this new path only requires the Plex url, port and token to be configured.